### PR TITLE
ci: add zizmor workflow

### DIFF
--- a/.github/workflows/ci-security.yaml
+++ b/.github/workflows/ci-security.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 DB Systel GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: CI security tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          advanced-security: false


### PR DESCRIPTION
Add CI security workflow using zizmor to scan GitHub Actions workflows for security issues.