### PR TITLE
ci: harden release-please app token permissions

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: write
-  issues: write
   pull-requests: write
 
 jobs:
@@ -24,6 +23,10 @@ jobs:
         with:
           client-id: ${{ secrets.RELEASER_CLIENT_ID }}
           private-key: ${{ secrets.RELEASER_PRIVATE_KEY }}
+          repositories: compliance-assistant
+          skip-token-revoke: false
+          permission-contents: write
+          permission-pull-requests: write
 
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:


### PR DESCRIPTION
Restricts the GitHub App token to only the necessary repository and permissions (contents, issues, pull-requests), and disables token caching via `skip-token-revoke: false`.